### PR TITLE
Create Caddy server e2e integration tests

### DIFF
--- a/.github/workflows/e2e_integration_test/Caddyfile
+++ b/.github/workflows/e2e_integration_test/Caddyfile
@@ -1,0 +1,35 @@
+# Caddyfile for Din e2e testing
+:8000 {
+	route /* {
+		# middleware declaration
+		din {
+			# middleware configurtion data, read by DinMiddleware.UnmarshalCaddyfile()
+			services {
+				eth {
+					providers {
+						https://eth.llamarpc.com:443 {
+							priority 0
+						}
+						https://ethereum-rpc.publicnode.com:443 {
+							priority 0
+						}
+						https://eth.rpc.blxrbdn.com:443 {
+							priority 0
+						}
+					}
+				}
+			}
+		}
+		# din reverse proxy directive configuration
+		# https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
+		reverse_proxy {
+			lb_policy din_reverse_proxy_policy
+			transport http {
+				tls
+				keepalive 10s
+			}
+			dynamic din_reverse_proxy_policy
+			header_up Host {upstream_hostport}
+		}
+	}
+}

--- a/.github/workflows/e2e_integration_test/e2e_integration_test.yml
+++ b/.github/workflows/e2e_integration_test/e2e_integration_test.yml
@@ -1,0 +1,43 @@
+name: e2e Caddy Integration Test
+
+'on':
+  pull_request:
+
+jobs:
+    test-caddy:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Set up Go
+              uses: actions/setup-go@v4
+              with:
+                go-version: '1.21'
+            
+            - name: Install xcaddy
+              run: |
+                export GOBIN=$HOME/go/bin
+                go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+
+            - name: Build Caddy with xcaddy
+              run: |
+                $HOME/go/bin/xcaddy build
+
+            - name: Use Custom Caddyfile and Run Caddy
+              run: |
+                $HOME/go/bin/xcaddy start --config ./.github/workflows/e2e_integration_test/Caddyfile
+              shell: bash
+
+            - name: Make the script executable
+              run: chmod +x ./.github/workflows/e2e_integration_test/send_requests.sh
+
+            - name: Send test requests
+              run: |
+                ./.github/workflows/e2e_integration_test/send_requests.sh
+              shell: bash
+              
+            - name: Stop Caddy server
+              run: |
+               $HOME/go/bin/xcaddy stop
+              shell: bash

--- a/.github/workflows/e2e_integration_test/send_requests.sh
+++ b/.github/workflows/e2e_integration_test/send_requests.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+for i in {1..10}; do
+    # Make the POST request and capture the HTTP status code
+    response=$(curl -s -o /dev/null -w "%{http_code}" localhost:8000/eth --data '{"id": 0, "jsonrpc": "2.0", "method": "eth_blockNumber"}' -H 'content-type: application/json')
+    
+    # Check if the response is 200
+    if [ "$response" -ne 200 ]; then
+        echo "Request $i failed with response code $response"
+        exit 1
+    else
+        echo "Request $i succeeded with response code $response"
+    fi
+done

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,38 +1,38 @@
 # yamllint disable rule:line-length rule:comments-indentation rule:comments
 ---
-name: Coverage Tests
-
-'on':
-  pull_request:
-
-jobs:
-  unit-tests:
-    runs-on: ubuntu-latest
-    env:
-      GOPRIVATE: github.com/openrelayxyz
-      MIN_COVER: 66
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          cache: true
-          cache-dependency-path: go.sum
-          go-version-file: go.mod
-          check-latest: true
-
-      - name: Test Build
-        run: |
-          go mod tidy
-
-      - name: Package Unit Tests
-        run: |
-          go test -count=1 -covermode=count -coverprofile=coverage.out ./...
-          go tool cover -func coverage.out
-          echo "PER_COVER=`go tool cover -func coverage.out | grep total | awk '{print substr($3, 1, length($3)-1)}'`" >> $GITHUB_ENV
-
-      # TODO: Uncomment this block to enforce minimum coverage, not enough tests yet
-      # - name: Package Low Coverage
-      #   if: ${{ env.PER_COVER < env.MIN_COVER }}
-      #   run: exit(1)
+    name: Coverage Tests
+    
+    'on':
+      pull_request:
+    
+    jobs:
+      unit-tests:
+        runs-on: ubuntu-latest
+        env:
+          GOPRIVATE: github.com/openrelayxyz
+          MIN_COVER: 66
+        steps:
+          - uses: actions/checkout@v3
+    
+          - name: Set up Go
+            uses: actions/setup-go@v4
+            with:
+              cache: true
+              cache-dependency-path: go.sum
+              go-version-file: go.mod
+              check-latest: true
+    
+          - name: Test Build
+            run: |
+              go mod tidy
+    
+          - name: Package Unit Tests
+            run: |
+              go test -count=1 -covermode=count -coverprofile=coverage.out ./...
+              go tool cover -func coverage.out
+              echo "PER_COVER=`go tool cover -func coverage.out | grep total | awk '{print substr($3, 1, length($3)-1)}'`" >> $GITHUB_ENV
+    
+          # TODO: Uncomment this block to enforce minimum coverage, not enough tests yet
+          # - name: Package Low Coverage
+          #   if: ${{ env.PER_COVER < env.MIN_COVER }}
+          #   run: exit(1)


### PR DESCRIPTION
This test runs the latest version of the caddy server locally, and runs a script that makes sure each request to the eth_blockNumber rpc endpoint returns a 200 response.

we are using 3 different public eth rpc's by default. The public endpoints can be swapped out whenever if they are not useful anymore.