### PR TITLE
delete unneeded header if present

### DIFF
--- a/modules/consts.go
+++ b/modules/consts.go
@@ -25,6 +25,9 @@ const (
 
 	// Additional Status Codes
 	StatusOriginUnreachable = 523
+
+	// Request/Response Header Keys
+	DinProviderInfo = "din-provider-info"
 )
 
 // String method to convert MyEnum to string

--- a/modules/din_select.go
+++ b/modules/din_select.go
@@ -69,8 +69,8 @@ func (d *DinSelect) Select(pool reverseproxy.UpstreamPool, r *http.Request, rw h
 					d.logger.Error("error signing request", zap.String("err", err.Error()), zap.String("machine_id", getMachineId()))
 				}
 			}
-			if v := r.Header.Get("din-provider-info"); v != "" {
-				rw.Header().Set("din-provider-info", provider.host)
+			if v := r.Header.Get(DinProviderInfo); v != "" {
+				rw.Header().Set(DinProviderInfo, provider.host)
 			}
 			repl.Set(RequestProviderKey, provider.host)
 			break


### PR DESCRIPTION
right now if a request does a retry attempt, we set the response writer wrapper body to its empty state but we don't do that for the added header. 

in this code, i explicitly check to see if the custom header is present, if it is, then i delete it.