### PR TITLE
remove prometheus health check instantiations

### DIFF
--- a/modules/service.go
+++ b/modules/service.go
@@ -98,7 +98,6 @@ func (s *service) healthCheck() {
 				// if there is an error getting the latest block number, mark the provider as a failure
 				s.logger.Warn("Error getting latest block number for provider", zap.String("provider", providerName), zap.String("service", s.Name), zap.Error(err), zap.String("machine_id", s.machineID))
 				provider.markPingFailure(s.HCThreshold)
-				s.sendLatestBlockMetric(provider.host, statusCode, provider.healthStatus.String(), providerBlockNumber)
 				return
 			}
 			blockTime = time.Now()
@@ -114,7 +113,6 @@ func (s *service) healthCheck() {
 					s.logger.Warn("Provider returned an error status code", zap.String("provider", providerName), zap.String("service", s.Name), zap.Int("status_code", statusCode), zap.String("machine_id", s.machineID))
 					provider.markPingFailure(s.HCThreshold)
 				}
-				s.sendLatestBlockMetric(provider.host, statusCode, provider.healthStatus.String(), providerBlockNumber)
 				return
 			} else {
 				provider.markPingSuccess(s.HCThreshold)
@@ -137,8 +135,6 @@ func (s *service) healthCheck() {
 			}
 
 			// TODO: create a check based on time window of a provider's latest block number
-			s.sendLatestBlockMetric(provider.host, statusCode, provider.healthStatus.String(), providerBlockNumber)
-
 			// add the current provider to the checked providers map
 			s.addHealthCheckToCheckedProviderList(provider.host, healthCheckEntry{blockNumber: providerBlockNumber, timestamp: &blockTime})
 		}(name, currentProvider) // Pass the loop variable to the goroutine
@@ -147,6 +143,8 @@ func (s *service) healthCheck() {
 	wg.Wait()
 }
 
+// sendLatestBlockMetric: sends the latest block number metric to Prometheus
+// This is not being used currently in an attempt to reduce the number of metrics being sent to Prometheus/Signoz
 func (s *service) sendLatestBlockMetric(providerName string, statusCode int, healthStatus string, providerBlockNumber int64) {
 	s.PrometheusClient.HandleLatestBlockMetric(&prom.PromLatestBlockMetricData{
 		Service:        s.Name,

--- a/modules/service_test.go
+++ b/modules/service_test.go
@@ -327,7 +327,6 @@ func TestHealthCheck(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockHttpClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.latestBlockResponse.postResponseBytes, &tt.latestBlockResponse.statusCode, tt.latestBlockResponse.err).Times(len(tt.service.Providers))
-			mockPrometheusClient.EXPECT().HandleLatestBlockMetric(gomock.Any()).Times(len(tt.service.Providers)).Times(len(tt.service.Providers))
 
 			tt.service.healthCheck()
 


### PR DESCRIPTION
Right now the bill for signoz is exceeding what our expectations are. In an attempt to reduce the amount of metrics being sent to otel/signoz, we are removing our regular health check methods from being required in the DIN proxy.