### PR TITLE
chore: rename "service" to "network" across the whole project

### DIFF
--- a/.github/workflows/e2e_integration_test/Caddyfile
+++ b/.github/workflows/e2e_integration_test/Caddyfile
@@ -4,7 +4,7 @@
 		# middleware declaration
 		din {
 			# middleware configurtion data, read by DinMiddleware.UnmarshalCaddyfile()
-			services {
+			networks {
 				eth {
 					providers {
 						https://eth.llamarpc.com:443 {

--- a/Caddyfile
+++ b/Caddyfile
@@ -25,7 +25,7 @@
 		# middleware declaration
 		din {
 			# middleware configurtion data, read by DinMiddleware.UnmarshalCaddyfile()
-			services {
+			networks {
 				eth {
 					methods web3_sha3 web3_clientVersion net_listening net_peerCount net_version eth_call eth_getBalance eth_estimateGas eth_createAccessList eth_getStorageAt eth_getCode eth_blockNumber eth_protocolVersion eth_syncing eth_sendRawTransaction eth_chainId eth_getLogs eth_getTransactionByHash eth_getTransactionReceipt eth_getTransactionCount eth_feeHistory eth_getBlockByNumber eth_getBlockByHash eth_gasPrice eth_getTransactionByBlockHashAndIndex eth_getTransactionByBlockNumberAndIndex eth_getBlockTransactionCountByNumber eth_getBlockTransactionCountByHash eth_getUncleCountByBlockNumber eth_getUncleCountByBlockHash eth_subscribe eth_unsubscribe eth_getUncleByBlockHashAndIndex eth_maxPriorityFeePerGas eth_getProof
 					providers {

--- a/lib/prometheus/prometheus_test.go
+++ b/lib/prometheus/prometheus_test.go
@@ -38,7 +38,7 @@ func TestHandleRequestMetric(t *testing.T) {
 			duration:     1 * time.Second,
 			data: &PromRequestMetricData{
 				Method:         "POST",
-				Service:        "/ethereum",
+				Network:        "/ethereum",
 				Provider:       "infura",
 				HostName:       "node1",
 				ResponseStatus: 200,
@@ -61,7 +61,7 @@ func TestHandleRequestMetric(t *testing.T) {
 			duration:     1 * time.Second,
 			data: &PromRequestMetricData{
 				Method:         "POST",
-				Service:        "/ethereum",
+				Network:        "/ethereum",
 				Provider:       "infura",
 				HostName:       "node1",
 				ResponseStatus: 200,
@@ -120,7 +120,7 @@ func TestHandleLatestBlockMetric(t *testing.T) {
 		{
 			name: "Valid Data",
 			data: &PromLatestBlockMetricData{
-				Service:        "/ethereum",
+				Network:        "/ethereum",
 				Provider:       "infura",
 				ResponseStatus: 200,
 				HealthStatus:   "healthy",
@@ -137,7 +137,7 @@ func TestHandleLatestBlockMetric(t *testing.T) {
 		{
 			name: "Invalid Data",
 			data: &PromLatestBlockMetricData{
-				Service:        "/ethereum",
+				Network:        "/ethereum",
 				Provider:       "infura",
 				ResponseStatus: 500,
 				HealthStatus:   "unhealthy",

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -231,7 +231,7 @@ func (d *DinMiddleware) UnmarshalCaddyfile(dispenser *caddyfile.Dispenser) error
 	}
 	for dispenser.Next() { // Skip the directive name
 		switch dispenser.Val() {
-		case "services":
+		case "networks":
 			for n1 := dispenser.Nesting(); dispenser.NextBlock(n1); {
 				networkName := dispenser.Val()
 				d.Networks[networkName] = NewNetwork(networkName) // Create a new network object

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -231,7 +231,7 @@ func (d *DinMiddleware) UnmarshalCaddyfile(dispenser *caddyfile.Dispenser) error
 	}
 	for dispenser.Next() { // Skip the directive name
 		switch dispenser.Val() {
-		case "networks":
+		case "services":
 			for n1 := dispenser.Nesting(); dispenser.NextBlock(n1); {
 				networkName := dispenser.Val()
 				d.Networks[networkName] = NewNetwork(networkName) // Create a new network object

--- a/modules/network.go
+++ b/modules/network.go
@@ -57,21 +57,21 @@ func NewNetwork(name string) *network {
 	}
 }
 
-func (s *network) startHealthcheck() {
-	s.healthCheck()
-	ticker := time.NewTicker(time.Second * time.Duration(s.HCInterval))
+func (n *network) startHealthcheck() {
+	n.healthCheck()
+	ticker := time.NewTicker(time.Second * time.Duration(n.HCInterval))
 	go func() {
 		// Keep an index for RPC request IDs
 		for i := 0; ; i++ {
 			select {
 			// Cleanup if the quit channel gets closed. Right now nothing closes this channel, but
 			// once we integrate the authentication work there's code that should.
-			case <-s.quit:
+			case <-n.quit:
 				ticker.Stop()
 				return
 			case <-ticker.C:
 				// Set up the healthcheck request with authentication for this provider.
-				s.healthCheck()
+				n.healthCheck()
 			}
 		}
 	}()
@@ -82,23 +82,23 @@ type healthCheckEntry struct {
 	timestamp   *time.Time
 }
 
-func (s *network) healthCheck() {
+func (n *network) healthCheck() {
 	// wait group to wait for all the providers to finish their health checks
 	var wg sync.WaitGroup
 	var blockTime time.Time
 
-	for name, currentProvider := range s.Providers {
+	for name, currentProvider := range n.Providers {
 		// check all of the providers simultaneously using async job management for more accurate blocknumber results.
 		wg.Add(1) // Increment the WaitGroup counter
 		go func(providerName string, provider *provider) {
 			defer wg.Done() // Decrement the counter when the goroutine completes
 			// get the latest block number from the current provider
-			providerBlockNumber, statusCode, err := s.getLatestBlockNumber(provider.HttpUrl, provider.Headers, provider.AuthClient())
+			providerBlockNumber, statusCode, err := n.getLatestBlockNumber(provider.HttpUrl, provider.Headers, provider.AuthClient())
 			if err != nil {
 				// if there is an error getting the latest block number, mark the provider as a failure
-				s.logger.Warn("Error getting latest block number for provider", zap.String("provider", providerName), zap.String("network", s.Name), zap.Error(err), zap.String("machine_id", s.machineID))
-				provider.markPingFailure(s.HCThreshold)
-				s.sendLatestBlockMetric(provider.host, statusCode, provider.healthStatus.String(), providerBlockNumber)
+				n.logger.Warn("Error getting latest block number for provider", zap.String("provider", providerName), zap.String("network", n.Name), zap.Error(err), zap.String("machine_id", n.machineID))
+				provider.markPingFailure(n.HCThreshold)
+				n.sendLatestBlockMetric(provider.host, statusCode, provider.healthStatus.String(), providerBlockNumber)
 				return
 			}
 			blockTime = time.Now()
@@ -107,49 +107,49 @@ func (s *network) healthCheck() {
 			if statusCode > 399 {
 				if statusCode == 429 {
 					// if the status code is 429, mark the provider as a warning
-					s.logger.Warn("Provider is rate limited", zap.String("provider", providerName), zap.String("network", s.Name), zap.String("machine_id", s.machineID))
+					n.logger.Warn("Provider is rate limited", zap.String("provider", providerName), zap.String("network", n.Name), zap.String("machine_id", n.machineID))
 					provider.markPingWarning()
 				} else {
 					// if the status code is greater than 399, mark the provider as a failure
-					s.logger.Warn("Provider returned an error status code", zap.String("provider", providerName), zap.String("network", s.Name), zap.Int("status_code", statusCode), zap.String("machine_id", s.machineID))
-					provider.markPingFailure(s.HCThreshold)
+					n.logger.Warn("Provider returned an error status code", zap.String("provider", providerName), zap.String("network", n.Name), zap.Int("status_code", statusCode), zap.String("machine_id", n.machineID))
+					provider.markPingFailure(n.HCThreshold)
 				}
-				s.sendLatestBlockMetric(provider.host, statusCode, provider.healthStatus.String(), providerBlockNumber)
+				n.sendLatestBlockMetric(provider.host, statusCode, provider.healthStatus.String(), providerBlockNumber)
 				return
 			} else {
-				provider.markPingSuccess(s.HCThreshold)
+				provider.markPingSuccess(n.HCThreshold)
 			}
 
 			// Consistency health check
-			if s.LatestBlockNumber == 0 || s.LatestBlockNumber < providerBlockNumber {
+			if n.LatestBlockNumber == 0 || n.LatestBlockNumber < providerBlockNumber {
 				// if the current provider's latest block number is greater than the network's latest block number, update the network's latest block number,
 				// set the current provider as healthy and loop through all of the previously checked providers and set them as unhealthy
-				s.LatestBlockNumber = providerBlockNumber
+				n.LatestBlockNumber = providerBlockNumber
 				provider.markHealthy()
-				s.evaluateCheckedProviders()
-			} else if s.LatestBlockNumber == providerBlockNumber {
+				n.evaluateCheckedProviders()
+			} else if n.LatestBlockNumber == providerBlockNumber {
 				// if the current provider's latest block number is equal to the network's latest block number, set the current provider to healthy
 				provider.markHealthy()
-			} else if providerBlockNumber+s.BlockLagLimit < s.LatestBlockNumber {
+			} else if providerBlockNumber+n.BlockLagLimit < n.LatestBlockNumber {
 				// if the current provider's latest block number is below the network's latest block number by more than the acceptable threshold, set the current provider to warning
-				s.logger.Warn("Provider is lagging behind", zap.String("provider", providerName), zap.String("network", s.Name), zap.Int64("provider_block_number", providerBlockNumber), zap.Int64("network_block_number", s.LatestBlockNumber), zap.String("machine_id", s.machineID))
+				n.logger.Warn("Provider is lagging behind", zap.String("provider", providerName), zap.String("network", n.Name), zap.Int64("provider_block_number", providerBlockNumber), zap.Int64("network_block_number", n.LatestBlockNumber), zap.String("machine_id", n.machineID))
 				provider.markWarning()
 			}
 
 			// TODO: create a check based on time window of a provider's latest block number
-			s.sendLatestBlockMetric(provider.host, statusCode, provider.healthStatus.String(), providerBlockNumber)
+			n.sendLatestBlockMetric(provider.host, statusCode, provider.healthStatus.String(), providerBlockNumber)
 
 			// add the current provider to the checked providers map
-			s.addHealthCheckToCheckedProviderList(provider.host, healthCheckEntry{blockNumber: providerBlockNumber, timestamp: &blockTime})
+			n.addHealthCheckToCheckedProviderList(provider.host, healthCheckEntry{blockNumber: providerBlockNumber, timestamp: &blockTime})
 		}(name, currentProvider) // Pass the loop variable to the goroutine
 	}
 	// Wait for all goroutines to complete
 	wg.Wait()
 }
 
-func (s *network) sendLatestBlockMetric(providerName string, statusCode int, healthStatus string, providerBlockNumber int64) {
-	s.PrometheusClient.HandleLatestBlockMetric(&prom.PromLatestBlockMetricData{
-		Network:        s.Name,
+func (n *network) sendLatestBlockMetric(providerName string, statusCode int, healthStatus string, providerBlockNumber int64) {
+	n.PrometheusClient.HandleLatestBlockMetric(&prom.PromLatestBlockMetricData{
+		Network:        n.Name,
 		Provider:       providerName,
 		ResponseStatus: statusCode,
 		HealthStatus:   healthStatus,
@@ -157,40 +157,40 @@ func (s *network) sendLatestBlockMetric(providerName string, statusCode int, hea
 	})
 }
 
-func (s *network) getCheckedProviderHCList(providerName string) ([]healthCheckEntry, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	values, ok := s.CheckedProviders[providerName]
+func (n *network) getCheckedProviderHCList(providerName string) ([]healthCheckEntry, bool) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	values, ok := n.CheckedProviders[providerName]
 	return values, ok
 }
 
-func (s *network) setCheckedProviderHCList(providerName string, newHealthCheckList []healthCheckEntry) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.CheckedProviders[providerName] = newHealthCheckList
+func (n *network) setCheckedProviderHCList(providerName string, newHealthCheckList []healthCheckEntry) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.CheckedProviders[providerName] = newHealthCheckList
 }
 
 // evaluateCheckedProviders loops through all of the checked providers and sets them as unhealthy if they are not the current provider
-func (s *network) evaluateCheckedProviders() {
+func (n *network) evaluateCheckedProviders() {
 	// read lock the checked providers map
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	n.mu.RLock()
+	defer n.mu.RUnlock()
 	// loop through all of the checked providers and set them as unhealthy if they are not the current provider
-	checkedProviders := s.CheckedProviders
+	checkedProviders := n.CheckedProviders
 	for providerName, healthCheckList := range checkedProviders {
-		if healthCheckList[0].blockNumber+s.BlockLagLimit < s.LatestBlockNumber {
-			s.Providers[providerName].markWarning()
+		if healthCheckList[0].blockNumber+n.BlockLagLimit < n.LatestBlockNumber {
+			n.Providers[providerName].markWarning()
 		}
 	}
 }
 
 // addHealthCheckToCheckedProviderList adds a new healthCheckEntry to the beginning of the CheckedProviders healthCheck list for the given provider
 // the list will not exceed 10 entries
-func (s *network) addHealthCheckToCheckedProviderList(providerName string, healthCheckInput healthCheckEntry) {
+func (n *network) addHealthCheckToCheckedProviderList(providerName string, healthCheckInput healthCheckEntry) {
 	// if the provider is not in the checked providers map, add it with its initial block number and timestamp
-	currentHealthCheckList, ok := s.getCheckedProviderHCList(providerName)
+	currentHealthCheckList, ok := n.getCheckedProviderHCList(providerName)
 	if !ok {
-		s.setCheckedProviderHCList(providerName, []healthCheckEntry{healthCheckInput})
+		n.setCheckedProviderHCList(providerName, []healthCheckEntry{healthCheckInput})
 		return
 	}
 
@@ -200,19 +200,19 @@ func (s *network) addHealthCheckToCheckedProviderList(providerName string, healt
 	// if the old slice is full at 10 entries, we need to remove the last entry and append the rest of the entries to the new slice
 	if len(currentHealthCheckList) == 10 {
 		currentHealthCheckList = append(newHealthCheckList, currentHealthCheckList[:9]...)
-		s.setCheckedProviderHCList(providerName, currentHealthCheckList)
+		n.setCheckedProviderHCList(providerName, currentHealthCheckList)
 	} else {
 		// if the old slice is not full, we can copy the old slice to the new slice and add the new entry to index 0
 		currentHealthCheckList = append(newHealthCheckList, currentHealthCheckList...)
-		s.setCheckedProviderHCList(providerName, currentHealthCheckList)
+		n.setCheckedProviderHCList(providerName, currentHealthCheckList)
 	}
 }
 
-func (s *network) getLatestBlockNumber(httpUrl string, headers map[string]string, ac auth.IAuthClient) (int64, int, error) {
-	payload := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","method": "%s","params":[],"id":1}`, s.HCMethod))
+func (n *network) getLatestBlockNumber(httpUrl string, headers map[string]string, ac auth.IAuthClient) (int64, int, error) {
+	payload := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","method": "%s","params":[],"id":1}`, n.HCMethod))
 
 	// Send the POST request
-	resBytes, statusCode, err := s.HTTPClient.Post(httpUrl, headers, []byte(payload), ac)
+	resBytes, statusCode, err := n.HTTPClient.Post(httpUrl, headers, []byte(payload), ac)
 	if err != nil {
 		return 0, 0, errors.Wrap(err, "Error sending POST request")
 	}
@@ -255,6 +255,6 @@ func (s *network) getLatestBlockNumber(httpUrl string, headers map[string]string
 	return blockNumber, *statusCode, nil
 }
 
-func (s *network) close() {
-	close(s.quit)
+func (n *network) close() {
+	close(n.quit)
 }


### PR DESCRIPTION
This is a basic name refactor across the whole project.

**The Caddyfile will need to be updated to support this.**

The only place that this wasn't done was within the [prometheus library](https://github.com/DIN-center/din-caddy-plugins/pull/53/files#diff-a9eacc33ac8e1fcc4a85b5d424e486fca382415817e9926ed19317e365cf5828R48) because if we renamed these values then our signoz dashboards/alerts would be disrupted
