### PR TITLE
Feature: ensure block numbers do not drastically change for greater or lesser

### DIFF
--- a/.github/workflows/e2e_integration_test/Caddyfile
+++ b/.github/workflows/e2e_integration_test/Caddyfile
@@ -16,7 +16,7 @@
 						https://ethereum-rpc.publicnode.com:443 {
 							priority 0
 						}
-						https://eth.rpc.blxrbdn.com:443 {
+						https://api.zan.top/eth-mainnet {
 							priority 0
 						}
 					}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/DIN-center/din-caddy-plugins
 
-go 1.22
-
+go 1.21.7
 
 require (
 	github.com/DIN-center/din-sc/apps/din-go v0.0.0-20241029204756-63334786749d

--- a/modules/consts.go
+++ b/modules/consts.go
@@ -23,6 +23,7 @@ const (
 	DefaultHCThreshold             = 2
 	DefaultHCInterval              = 5
 	DefaultBlockLagLimit           = int64(5)
+	DefaultBlockNumberDelta        = int64(10)
 	DefaultMaxRequestPayloadSizeKB = int64(4096)
 	DefaultRequestAttemptCount     = 5
 

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -533,6 +533,13 @@ func (d *DinMiddleware) UnmarshalCaddyfile(dispenser *caddyfile.Dispenser) error
 							return fmt.Errorf("invalid healthcheck blocklag limit: %v", err)
 						}
 						d.Networks[networkName].BlockLagLimit = int64(limit)
+					case "healthcheck_blocknumber_delta":
+						dispenser.Next()
+						blockNumberDelta, err := strconv.Atoi(dispenser.Val())
+						if err != nil {
+							return fmt.Errorf("invalid healthcheck blocknumber delta: %v", err)
+						}
+						d.Networks[networkName].BlockNumberDelta = int64(blockNumberDelta)
 					case "max_request_payload_size_kb":
 						dispenser.Next()
 						size, err := strconv.Atoi(dispenser.Val())


### PR DESCRIPTION
Previously, we have seen bugs amongst providers where for example if the general block range is around 100-105, a provider may fail and jump to 500, then back down to 103. 

As a result, this update implements the concept of a `blockNumberDelta` value that makes it so providers can't go over or under and a certain range when it comes to latest block numbers that they are reporting.

For example, now if the `blockNumberDelta = 10`, if a provider jumps up to 500, then they are deemed as `unhealthy` and need to go through the healthiness process to prove that they are healthy again.

I also did a general refactor of the healthCheck logic by abstracting out the checks into their own functions and reflecting this in the tests themselves.